### PR TITLE
Pasada la lógica del token a util en lugar de context-reducer

### DIFF
--- a/frontend-app/src/components/Buttonpopup.js
+++ b/frontend-app/src/components/Buttonpopup.js
@@ -31,6 +31,9 @@ const useStyles = makeStyles({
     const classes = useStyles();
 
     return(
+        <p>Texto temporal, el código original daba error</p>
+        /*
+        TODO: LO DEJAMOS ASI DE MOMENTO PORQUE ESTE CODIGO DABA ERROR
         <React.Fragment>
             <Modal open={open} onClose={() => setOpen(false)}>
                 <Card className={classes.card}>
@@ -43,8 +46,7 @@ const useStyles = makeStyles({
                 Edit Profile
             </Button>
             </Modal>
-        </React.Fragment>
-
+        </React.Fragment>*/
     )
 }
 export default ButtonPopup;

--- a/frontend-app/src/components/Header.js
+++ b/frontend-app/src/components/Header.js
@@ -13,6 +13,7 @@ import Toolbar from '@material-ui/core/Toolbar';
 import Typography from '@material-ui/core/Typography';
 import Button from '@material-ui/core/Button';
 import './Header.css';
+import getToken from "../utils/tokenHelper";
 
 const useStyles = makeStyles(theme => ({
     root: {
@@ -28,7 +29,7 @@ const useStyles = makeStyles(theme => ({
 
 export default function ButtonAppBar() {
     const classes = useStyles();
-    const {state, dispatch} = useContext(AuthContext);
+    const {dispatch} = useContext(AuthContext); // no incluyo state porque no lo estamos usando. reañadir si hiciera falta
 
     return (
         <div className={classes.root}>
@@ -37,7 +38,7 @@ export default function ButtonAppBar() {
                     <Typography variant="h6" className={classes.title}>
                         <Link to={HOME}><span style={{color: "white"}}>Labori</span></Link>
                     </Typography>
-                    {state.token ?
+                    {getToken() ?
                         <>
                             <Button color="inherit">
                                 <Link to={FEED} className="headerBtn">

--- a/frontend-app/src/utils/reducer.js
+++ b/frontend-app/src/utils/reducer.js
@@ -5,19 +5,26 @@ const initialState = {
 };
 
 // actions
-const SAVE_CURRENT_TOKEN_ON_STATE = 'SAVE_CURRENT_TOKEN_ON_STATE'; // si existe un token en localStorage, guardarlo en initialState
 const DO_LOGOUT = 'DO_LOGOUT'; // para vaciar el token (esté activo o caducado) y redirigir a login
+// esta acción está en desuso, pero mantengo el código comentado para futura referencia
+//const SAVE_CURRENT_TOKEN_ON_STATE = 'SAVE_CURRENT_TOKEN_ON_STATE'; // si existe un token en localStorage, guardarlo en initialState
+
 
 const AuthorizationReducer = (state = initialState, action) => {
         const newState = {...state};
         const {type} = {...action};
 
+        // esta acción ya no la usamos, consultamos directamente el token con getToken() de tokenHelper.js
+        // lo dejo aquí igualmente para futura referencia
+        /*
         if (type === SAVE_CURRENT_TOKEN_ON_STATE) {
             if (localStorage.getItem("TOKEN_KEY")) {
                 newState.token = localStorage.getItem("TOKEN_KEY");
                 console.log("Token cogido de localStorage y guardado en state.");
             }
         }
+        */
+
         if (type === DO_LOGOUT) {
             newState.token = null;
             localStorage.removeItem("TOKEN_KEY");

--- a/frontend-app/src/utils/tokenHelper.js
+++ b/frontend-app/src/utils/tokenHelper.js
@@ -1,0 +1,3 @@
+export default function getToken() {
+    return localStorage.getItem("TOKEN_KEY")
+}

--- a/frontend-app/src/views/Profilepage.js
+++ b/frontend-app/src/views/Profilepage.js
@@ -1,6 +1,7 @@
 /* BASIC STUFF */
 import React, {useState, useEffect, useContext} from 'react';
 import {AuthContext} from "../utils/AuthFront/context";
+import getToken from "../utils/tokenHelper";
 
 /* COMPONENTS & STYLES */
 import ButtonPopup from "../components/Buttonpopup";
@@ -42,7 +43,7 @@ function Profilepage() {
     const classes = useStyles();
 
     // recogemos lo proveído por el context
-    const {state, dispatch} = useContext(AuthContext);
+    const {dispatch} = useContext(AuthContext);  // no incluyo state porque no lo estamos usando. reañadir si hiciera falta
 
     // creamos los hooks de estado con los datos del usuario
     const [userData, setUserData] = useState({
@@ -55,7 +56,7 @@ function Profilepage() {
     useEffect(() => {
 
         const fetchData = async () => {
-            const url = `http://127.0.0.1/api/users/?token=` + state.token;
+            const url = `http://127.0.0.1/api/users/?token=` + getToken();
             const options = {
                 method: 'GET',
                 headers: new Headers({
@@ -92,7 +93,7 @@ function Profilepage() {
 
         fetchData();
 
-    }, [dispatch, state.token]);
+    }, [dispatch]);
 
 
     return (<AuthContext.Consumer>


### PR DESCRIPTION
Como hablado ayer con Carlos, ahora el token no se guarda en un state en el reducer, lo cogemos siempre de localStorage.

Se puede hacer fácilmente usando `getToken()` con tan solo importar el helper:
`import getToken from "./utils/tokenHelper";`